### PR TITLE
feat: ability to specify environment

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,10 +5,11 @@ const { name } = require('./package.json');
 exports.sourceNodes = async ({ actions, createNodeId, createContentDigest, reporter }, options) => {
   if (!options.spaceId) return reporter.error(`🚨  ${name}:spaceId is a required option `);
   if (!options.accessToken) return reporter.error(`🚨  ${name}:accessToken is a required option `);
+  if (!options.environment) options.environment = 'master';
 
   const { createNode } = actions
-  const { spaceId, accessToken } = options
-  const url = `https://cdn.contentful.com/spaces/${spaceId}/environments/master/locales?access_token=${accessToken}`;
+  const { spaceId, accessToken, environment } = options
+  const url = `https://cdn.contentful.com/spaces/${spaceId}/environments/${environment}/locales?access_token=${accessToken}`;
   try {
     // Download data from the Contentful Delivery API.
     const response = await fetch(url)


### PR DESCRIPTION
Contentful allows setting up per-environment locales. 
This change allows users to pass an optional `environment` property so they aren't limited to querying information from the `master` environment.